### PR TITLE
Codebook Scrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ bin-release/
 
 # Executables
 *.pyc
-*.sqlite3
+*.sqlite3git
 
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All noteable changes to this project are documented in this file. This project a
 
 Features
 
-- Built ScrapMEPS class and mgmt command for fetching ssp files from the MEPS data center
+- Built ScrapMEPSSSP class and mgmt command for fetching ssp files from the MEPS data center
+- Built ScrapMEPSCodebook class and mgmt command for fetching codebook data from the MEPS data center
 
 Updates:
 

--- a/meps_dev/components/management/commands/scrap_meps_codebook.py
+++ b/meps_dev/components/management/commands/scrap_meps_codebook.py
@@ -1,29 +1,29 @@
 from django.core.management.base import BaseCommand
-from meps_dev.components.scrapper import ScrapMEPS
+from meps_dev.components.scrapper import ScrapMEPSCodebook
 
 
 class Command(BaseCommand):
     """ Management command to scrap data files from the MEPS site. Run in terminal.
         ex:
-            python manage.py scrap_meps
-            python manage.py scrap_meps --years 2016 2019 --download_dir "custom/path" --sleep 25
+            python manage.py scrap_meps_codebook
+            python manage.py scrap_meps_codebook --years 2016 2019 --output_dir "custom/path" --sleep 25
     """
 
-    help = "Scraps the MEPS page for zipped data files "
+    help = "Scraps the MEPS page variable information "
 
     def add_arguments(self, parser):
         parser.add_argument("--years", nargs="*", type=int, help="declare a years to scrap data for: 2019 2020")
 
-        parser.add_argument("--download_dir", nargs="?", help="declare the path to the download directory")
+        parser.add_argument("--output_dir", nargs="?", help="declare the path to the download directory")
 
         parser.add_argument("--sleep", nargs="?", type=int, help="declare how many seconds to wait between downloads")
 
     def handle(self, *args, **options):
 
         kwargs = {}
-        for arg in ["years", "download_dir", "sleep"]:
+        for arg in ["years", "output_dir", "sleep"]:
             if options[arg] is not None:
                 kwargs.update({arg: options[arg]})
 
-        scrapper = ScrapMEPS(**kwargs)
+        scrapper = ScrapMEPSCodebook(**kwargs)
         scrapper.run()

--- a/meps_dev/components/management/commands/scrap_meps_ssp.py
+++ b/meps_dev/components/management/commands/scrap_meps_ssp.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+from meps_dev.components.scrapper import ScrapMEPSSSP
+
+
+class Command(BaseCommand):
+    """ Management command to scrap data files from the MEPS site. Run in terminal.
+        ex:
+            python manage.py scrap_meps_ssp
+            python manage.py scrap_meps_ssp --years 2016 2019 --download_dir "custom/path" --sleep 25
+    """
+
+    help = "Scraps the MEPS page for zipped data files "
+
+    def add_arguments(self, parser):
+        parser.add_argument("--years", nargs="*", type=int, help="declare a years to scrap data for: 2019 2020")
+
+        parser.add_argument("--download_dir", nargs="?", help="declare the path to the download directory")
+
+        parser.add_argument("--sleep", nargs="?", type=int, help="declare how many seconds to wait between downloads")
+
+    def handle(self, *args, **options):
+
+        kwargs = {}
+        for arg in ["years", "download_dir", "sleep"]:
+            if options[arg] is not None:
+                kwargs.update({arg: options[arg]})
+
+        scrapper = ScrapMEPSSSP(**kwargs)
+        scrapper.run()

--- a/meps_dev/components/reference.py
+++ b/meps_dev/components/reference.py
@@ -20,7 +20,7 @@ DATA_FILES_YEARS = [
 ]
 
 # Full Year Consolidated Data Files
-FYCDF_PUF_LOOKUP = {
+FYCDF_PUF_SSP_LOOKUP = {
     2018: "h209ssp.zip",
     2017: "h201ssp.zip",
     2016: "h192ssp.zip",
@@ -36,9 +36,25 @@ FYCDF_PUF_LOOKUP = {
     2006: "h105ssp.zip",
     2005: "h97ssp.zip",
 }
+FYCDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H209",
+    2017: "H201",
+    2016: "H192",
+    2015: "H181",
+    2014: "H171",
+    2013: "H163",
+    2012: "H155",
+    2011: "H147",
+    2010: "H138",
+    2009: "H129",
+    2008: "H121",
+    2007: "H113",
+    2006: "H105",
+    2005: "H97",
+}
 
 # Full Year Population Characteristics Data Files
-FYPCDF_PUF_LOOKUP = {
+FYPCDF_PUF_SSP_LOOKUP = {
     2018: "h204ssp.zip",
     2017: "h194ssp.zip",
     2016: "h184ssp.zip",
@@ -54,9 +70,25 @@ FYPCDF_PUF_LOOKUP = {
     2006: "h105ssp.zip",
     2005: "h97ssp.zip",
 }
+FYPCDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H204",
+    2017: "H194",
+    2016: "H184",
+    2015: "H174",
+    2014: "H165",
+    2013: "H157",
+    2012: "H149",
+    2011: "H141",
+    2010: "H132",
+    2009: "H123",
+    2008: "H115",
+    2007: "H113",
+    2006: "H105",
+    2005: "H97",
+}
 
 # Medical Conditions Data Files
-MCDF_PUF_LOOKUP = {
+MCDF_PUF_SSP_LOOKUP = {
     2018: "h207ssp.zip",
     2017: "h199ssp.zip",
     2016: "h190ssp.zip",
@@ -72,9 +104,25 @@ MCDF_PUF_LOOKUP = {
     2006: "h104ssp.zip",
     2005: "h96ssp.zip",
 }
+MCDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H207",
+    2017: "H199",
+    2016: "H190",
+    2015: "H180",
+    2014: "H170",
+    2013: "H162",
+    2012: "H154",
+    2011: "H146",
+    2010: "H137",
+    2009: "H128",
+    2008: "H120",
+    2007: "H112",
+    2006: "H104",
+    2005: "H96",
+}
 
 # Prescribed Medicines Data Files
-PMDF_PUF_LOOKUP = {
+PMDF_PUF_SSP_LOOKUP = {
     2018: "h206assp.zip",
     2017: "h197assp.zip",
     2016: "h188assp.zip",
@@ -90,9 +138,25 @@ PMDF_PUF_LOOKUP = {
     2006: "h102assp.zip",
     2005: "h94assp.zip",
 }
+PMDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206A",
+    2017: "H197A",
+    2016: "H188A",
+    2015: "H178A",
+    2014: "H168A",
+    2013: "H160A",
+    2012: "H152A",
+    2011: "H144A",
+    2010: "H135A",
+    2009: "H126A",
+    2008: "H118A",
+    2007: "H110A",
+    2006: "H102A",
+    2005: "H94A",
+}
 
 # Dental Visits Data Files
-DVDF_PUF_LOOKUP = {
+DVDF_PUF_SSP_LOOKUP = {
     2018: "h206bssp.zip",
     2017: "h197bssp.zip",
     2016: "h188bssp.zip",
@@ -108,9 +172,26 @@ DVDF_PUF_LOOKUP = {
     2006: "h102bssp.zip",
     2005: "h94bssp.zip",
 }
+DVDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206B",
+    2017: "H197B",
+    2016: "H188B",
+    2015: "H178B",
+    2014: "H168B",
+    2013: "H160B",
+    2012: "H152B",
+    2011: "H144B",
+    2010: "H135B",
+    2009: "H126B",
+    2008: "H118B",
+    2007: "H110B",
+    2006: "H102B",
+    2005: "H94B",
+}
+
 
 # Other Medical Expenses Data Files
-OMEDF_PUF_LOOKUP = {
+OMEDF_PUF_SSP_LOOKUP = {
     2018: "h206cssp.zip",
     2017: "h197cssp.zip",
     2016: "h188cssp.zip",
@@ -126,9 +207,26 @@ OMEDF_PUF_LOOKUP = {
     2006: "h102cssp.zip",
     2005: "h94cssp.zip",
 }
+OMEDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206C",
+    2017: "H197C",
+    2016: "H188C",
+    2015: "H178C",
+    2014: "H168C",
+    2013: "H160C",
+    2012: "H152C",
+    2011: "H144C",
+    2010: "H135C",
+    2009: "H126C",
+    2008: "H118C",
+    2007: "H110C",
+    2006: "H102C",
+    2005: "H94C",
+}
+
 
 # Hospital Inpatient Stays Data Files
-HISDF_PUF_LOOKUP = {
+HISDF_PUF_SSP_LOOKUP = {
     2018: "h206dssp.zip",
     2017: "h197dssp.zip",
     2016: "h188dssp.zip",
@@ -144,9 +242,26 @@ HISDF_PUF_LOOKUP = {
     2006: "h102dssp.zip",
     2005: "h94dssp.zip",
 }
+HISDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206D",
+    2017: "H197D",
+    2016: "H188D",
+    2015: "H178D",
+    2014: "H168D",
+    2013: "H160D",
+    2012: "H152D",
+    2011: "H144D",
+    2010: "H135D",
+    2009: "H126D",
+    2008: "H118D",
+    2007: "H110D",
+    2006: "H102D",
+    2005: "H94D",
+}
+
 
 # Emergency Room Visits Data Files
-ERVDF_PUF_LOOKUP = {
+ERVDF_PUF_SSP_LOOKUP = {
     2018: "h206essp.zip",
     2017: "h197essp.zip",
     2016: "h188essp.zip",
@@ -162,9 +277,26 @@ ERVDF_PUF_LOOKUP = {
     2006: "h102essp.zip",
     2005: "h94essp.zip",
 }
+ERVDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206E",
+    2017: "H197E",
+    2016: "H188E",
+    2015: "H178E",
+    2014: "H168E",
+    2013: "H160E",
+    2012: "H152E",
+    2011: "H144E",
+    2010: "H135E",
+    2009: "H126E",
+    2008: "H118E",
+    2007: "H110E",
+    2006: "H102E",
+    2005: "H94E",
+}
+
 
 # Outpatient Visits Data Files
-OVDF_PUF_LOOKUP = {
+OVDF_PUF_SSP_LOOKUP = {
     2018: "h206fssp.zip",
     2017: "h197fssp.zip",
     2016: "h188fssp.zip",
@@ -180,9 +312,26 @@ OVDF_PUF_LOOKUP = {
     2006: "h102fssp.zip",
     2005: "h94fssp.zip",
 }
+OVDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206F",
+    2017: "H197F",
+    2016: "H188F",
+    2015: "H178F",
+    2014: "H168F",
+    2013: "H160F",
+    2012: "H152F",
+    2011: "H144F",
+    2010: "H135F",
+    2009: "H126F",
+    2008: "H118F",
+    2007: "H110F",
+    2006: "H102F",
+    2005: "H94F",
+}
+
 
 # Office-Based Medical Provider Visits Data Files
-OBMPVDF_PUF_LOOKUP = {
+OBMPVDF_PUF_SSP_LOOKUP = {
     2018: "h206gssp.zip",
     2017: "h197gssp.zip",
     2016: "h188gssp.zip",
@@ -198,9 +347,26 @@ OBMPVDF_PUF_LOOKUP = {
     2006: "h102gssp.zip",
     2005: "h94gssp.zip",
 }
+OBMPVDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206G",
+    2017: "H197G",
+    2016: "H188G",
+    2015: "H178G",
+    2014: "H168G",
+    2013: "H160G",
+    2012: "H152G",
+    2011: "H144G",
+    2010: "H135G",
+    2009: "H126G",
+    2008: "H118G",
+    2007: "H110G",
+    2006: "H102G",
+    2005: "H94G",
+}
+
 
 # Home Health Data Files
-HHDF_PUF_LOOKUP = {
+HHDF_PUF_SSP_LOOKUP = {
     2018: "h206hssp.zip",
     2017: "h197hssp.zip",
     2016: "h188hssp.zip",
@@ -215,4 +381,20 @@ HHDF_PUF_LOOKUP = {
     2007: "h110hssp.zip",
     2006: "h102hssp.zip",
     2005: "h94hssp.zip",
+}
+HHDF_PUF_CODEBOOK_LOOKUP = {
+    2018: "H206H",
+    2017: "H197H",
+    2016: "H188H",
+    2015: "H178H",
+    2014: "H168H",
+    2013: "H160H",
+    2012: "H152H",
+    2011: "H144H",
+    2010: "H135H",
+    2009: "H126H",
+    2008: "H118H",
+    2007: "H110H",
+    2006: "H102H",
+    2005: "H94H",
 }

--- a/meps_dev/components/scrapper.py
+++ b/meps_dev/components/scrapper.py
@@ -33,6 +33,7 @@ from meps_dev.components.reference import (
 )
 from meps_dev.utilities.universal_utilities import UniversalUtilityFunctions
 
+
 class ScrapMEPSSSP:
     """ Web scrapper class. Uses Selenium to navigate to the MEPS AHRQ Data files page in browser. Downloads ssp files
     to the specified input file location. Requires a chromedriver associated with the version of chrome running on
@@ -113,6 +114,7 @@ class ScrapMEPSSSP:
                 f"numbers have been updated"
             )
 
+
 class ScrapMEPSCodebook:
     """ Web scrapper class. Uses Selenium to navigate to the MEPS AHRQ Data files Codebook page in browser. Extracts
     For each variable in a the code book sotres the variable name, description and format. Requires a chromedriver 
@@ -132,7 +134,7 @@ class ScrapMEPSCodebook:
         self.years = years if years else DATA_FILES_YEARS
         self.output_dir = output_dir if output_dir else os.path.join(expanduser("~"), "meps", "meps_data")
         self.sleep = sleep
-    
+
     def run(self):
         """ Primary entry point of ScrapMEPS """
 
@@ -158,7 +160,7 @@ class ScrapMEPSCodebook:
             os.makedirs(output_dir)
 
         executable_path = os.path.join(os.path.join(expanduser("~"), "meps", "meps_dev", "chromedriver"))
-        driver = webdriver.Chrome(executable_path=executable_path)  
+        driver = webdriver.Chrome(executable_path=executable_path)
 
         for year in self.years:
             PUFId = year_lookup[year]
@@ -178,8 +180,8 @@ class ScrapMEPSCodebook:
             vals = table_text[last_header_ind:]
 
             variables = []
-            for field_num in range(int(len(vals)/len(keys))):
-                variables.append(vals[field_num*last_header_ind+0])
+            for field_num in range(int(len(vals) / len(keys))):
+                variables.append(vals[field_num * last_header_ind + 0])
 
             # navigate to each variable page
             codebook = {}
@@ -196,14 +198,13 @@ class ScrapMEPSCodebook:
                 for row in var_table.split("\n"):
                     key_val = row.split(":")
                     variable_dict.update({key_val[0]: key_val[1].strip(" ")})
-                
+
                 # update codebook
                 codebook[variable] = variable_dict
-            
+
             # write to path
             UniversalUtilityFunctions.write_data_to_file(
                 data=codebook,
                 output_file_path=os.path.join(output_dir, f"{PUFId}_codebook"),
-                output_file_format="json"
+                output_file_format="json",
             )
-            

--- a/meps_dev/components/scrapper.py
+++ b/meps_dev/components/scrapper.py
@@ -8,21 +8,32 @@ from selenium import webdriver
 from meps_dev.components.reference import (
     DATA_FILES_BASE_URL,
     DATA_FILES_YEARS,
-    FYCDF_PUF_LOOKUP,
-    FYPCDF_PUF_LOOKUP,
-    MCDF_PUF_LOOKUP,
-    PMDF_PUF_LOOKUP,
-    DVDF_PUF_LOOKUP,
-    OMEDF_PUF_LOOKUP,
-    HISDF_PUF_LOOKUP,
-    ERVDF_PUF_LOOKUP,
-    OVDF_PUF_LOOKUP,
-    OBMPVDF_PUF_LOOKUP,
-    HHDF_PUF_LOOKUP,
+    FYCDF_PUF_SSP_LOOKUP,
+    FYPCDF_PUF_SSP_LOOKUP,
+    MCDF_PUF_SSP_LOOKUP,
+    PMDF_PUF_SSP_LOOKUP,
+    DVDF_PUF_SSP_LOOKUP,
+    OMEDF_PUF_SSP_LOOKUP,
+    HISDF_PUF_SSP_LOOKUP,
+    ERVDF_PUF_SSP_LOOKUP,
+    OVDF_PUF_SSP_LOOKUP,
+    OBMPVDF_PUF_SSP_LOOKUP,
+    HHDF_PUF_SSP_LOOKUP,
+    FYCDF_PUF_CODEBOOK_LOOKUP,
+    FYPCDF_PUF_CODEBOOK_LOOKUP,
+    MCDF_PUF_CODEBOOK_LOOKUP,
+    PMDF_PUF_CODEBOOK_LOOKUP,
+    DVDF_PUF_CODEBOOK_LOOKUP,
+    OMEDF_PUF_CODEBOOK_LOOKUP,
+    HISDF_PUF_CODEBOOK_LOOKUP,
+    ERVDF_PUF_CODEBOOK_LOOKUP,
+    OVDF_PUF_CODEBOOK_LOOKUP,
+    OBMPVDF_PUF_CODEBOOK_LOOKUP,
+    HHDF_PUF_CODEBOOK_LOOKUP,
 )
+from meps_dev.utilities.universal_utilities import UniversalUtilityFunctions
 
-
-class ScrapMEPS:
+class ScrapMEPSSSP:
     """ Web scrapper class. Uses Selenium to navigate to the MEPS AHRQ Data files page in browser. Downloads ssp files
     to the specified input file location. Requires a chromedriver associated with the version of chrome running on
     the local machine. Follow instructions on https://chromedriver.chromium.org/downloads to identify the driver suited
@@ -46,18 +57,18 @@ class ScrapMEPS:
     def run(self):
         """ Primary entry point of ScrapMEPS """
 
-        self.get_data_files(folder="consolidated", year_lookup=FYCDF_PUF_LOOKUP)
-        self.get_data_files(folder="population_characteristics", year_lookup=FYPCDF_PUF_LOOKUP)
-        self.get_data_files(folder="medical_conditions", year_lookup=MCDF_PUF_LOOKUP)
-        self.get_data_files(folder="prescribed_medicines", year_lookup=PMDF_PUF_LOOKUP)
+        self.get_data_files(folder="consolidated", year_lookup=FYCDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="population_characteristics", year_lookup=FYPCDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="medical_conditions", year_lookup=MCDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="prescribed_medicines", year_lookup=PMDF_PUF_SSP_LOOKUP)
 
-        self.get_data_files(folder="dental_visits", year_lookup=DVDF_PUF_LOOKUP)
-        self.get_data_files(folder="other_medical_expenses", year_lookup=OMEDF_PUF_LOOKUP)
-        self.get_data_files(folder="hospital_inpatient_stays", year_lookup=HISDF_PUF_LOOKUP)
-        self.get_data_files(folder="emergency_room_visits", year_lookup=ERVDF_PUF_LOOKUP)
-        self.get_data_files(folder="outpatient_vists", year_lookup=OVDF_PUF_LOOKUP)
-        self.get_data_files(folder="office_based_medical_provider_visits", year_lookup=OBMPVDF_PUF_LOOKUP)
-        self.get_data_files(folder="home_health", year_lookup=HHDF_PUF_LOOKUP)
+        self.get_data_files(folder="dental_visits", year_lookup=DVDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="other_medical_expenses", year_lookup=OMEDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="hospital_inpatient_stays", year_lookup=HISDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="emergency_room_visits", year_lookup=ERVDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="outpatient_vists", year_lookup=OVDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="office_based_medical_provider_visits", year_lookup=OBMPVDF_PUF_SSP_LOOKUP)
+        self.get_data_files(folder="home_health", year_lookup=HHDF_PUF_SSP_LOOKUP)
 
     def get_data_files(self, folder, year_lookup):
         """ Takes a folder name and a year to PUF no. lookup. Sets the download directory to the folder name within the
@@ -101,3 +112,98 @@ class ScrapMEPS:
                 f"The following files were not able to be fetched {', '.join(missing_files)} check if the PUF "
                 f"numbers have been updated"
             )
+
+class ScrapMEPSCodebook:
+    """ Web scrapper class. Uses Selenium to navigate to the MEPS AHRQ Data files Codebook page in browser. Extracts
+    For each variable in a the code book sotres the variable name, description and format. Requires a chromedriver 
+    associated with the version of chrome running on the local machine. Follow instructions on
+    https://chromedriver.chromium.org/downloads to identify the driver suited for the local machine. """
+
+    def __init__(self, years=None, output_dir=None, sleep=1):
+        """
+        Required Inputs:
+            None   
+        Optional Inputs:
+            years: years to fetch data for (list of ints ex: [2019, 2020])
+            output_dir: location of outputted codebook data
+            sleep: seconds to wait for urls to load before scrapping
+        """
+
+        self.years = years if years else DATA_FILES_YEARS
+        self.output_dir = output_dir if output_dir else os.path.join(expanduser("~"), "meps", "meps_data")
+        self.sleep = sleep
+    
+    def run(self):
+        """ Primary entry point of ScrapMEPS """
+
+        self.get_codebook_data(folder="consolidated", year_lookup=FYCDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="population_characteristics", year_lookup=FYPCDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="medical_conditions", year_lookup=MCDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="prescribed_medicines", year_lookup=PMDF_PUF_CODEBOOK_LOOKUP)
+
+        self.get_codebook_data(folder="dental_visits", year_lookup=DVDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="other_medical_expenses", year_lookup=OMEDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="hospital_inpatient_stays", year_lookup=HISDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="emergency_room_visits", year_lookup=ERVDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="outpatient_vists", year_lookup=OVDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="office_based_medical_provider_visits", year_lookup=OBMPVDF_PUF_CODEBOOK_LOOKUP)
+        self.get_codebook_data(folder="home_health", year_lookup=HHDF_PUF_CODEBOOK_LOOKUP)
+
+    def get_codebook_data(self, folder, year_lookup):
+        """ Takes a folder name and a year to PUF no. lookup. Spools up the chromedriver and extracts all codebook
+        data related to variables. Stores in the output directory. """
+
+        output_dir = os.path.join(self.output_dir, folder)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        executable_path = os.path.join(os.path.join(expanduser("~"), "meps", "meps_dev", "chromedriver"))
+        driver = webdriver.Chrome(executable_path=executable_path)  
+
+        for year in self.years:
+            PUFId = year_lookup[year]
+            url = f"https://www.meps.ahrq.gov/mepsweb/data_stats/download_data_files_codebook.jsp?PUFId={PUFId}"
+            driver.get(url)
+            time.sleep(self.sleep)
+            table_css = driver.find_element_by_css_selector(
+                "body > table:nth-child(24) > tbody > tr:nth-child(2) > td:nth-child(3) > table:nth-child(5) > tbody >"
+                " tr > td > table:nth-child(3)"
+            )
+            # generate codebook keys
+            table_str = table_css.text
+            table_text = table_str.split("\n")
+            last_header_ind = table_text.index("Description") + 1
+
+            keys = table_text[:last_header_ind]
+            vals = table_text[last_header_ind:]
+
+            variables = []
+            for field_num in range(int(len(vals)/len(keys))):
+                variables.append(vals[field_num*last_header_ind+0])
+
+            # navigate to each variable page
+            codebook = {}
+            for variable in variables:
+                variable_url = f"{url}&varName={variable}"
+                driver.get(variable_url)
+                time.sleep(self.sleep)
+                table_css = driver.find_element_by_css_selector(
+                    "body > table:nth-child(24) > tbody > tr:nth-child(2) > td:nth-child(3) > table:nth-child(5) > "
+                    "tbody > tr > td > table:nth-child(3)"
+                )
+                var_table = table_css.text
+                variable_dict = {}
+                for row in var_table.split("\n"):
+                    key_val = row.split(":")
+                    variable_dict.update({key_val[0]: key_val[1].strip(" ")})
+                
+                # update codebook
+                codebook[variable] = variable_dict
+            
+            # write to path
+            UniversalUtilityFunctions.write_data_to_file(
+                data=codebook,
+                output_file_path=os.path.join(output_dir, f"{PUFId}_codebook"),
+                output_file_format="json"
+            )
+            

--- a/meps_dev/utilities/universal_utilities.py
+++ b/meps_dev/utilities/universal_utilities.py
@@ -1,0 +1,62 @@
+import json
+import os
+import pickle
+
+
+class UniversalUtilityFunctions:
+    """ Class that contains utility functions used throughout codebase. Set up as class for easier use of mock
+    functions in testing. Contains the following:
+        - load_data_from_file: loads pickle or json from path
+        - write_data_to_file: writes data as pickle or json to path
+    """
+
+    @staticmethod
+    def load_data_from_file(file_path, file_format=None, verbosity=0):
+        """Loads a data object from a given file path"""
+
+        if file_format:
+            full_file_path = f"{file_path}.{file_format}"
+        else:
+            full_file_path = file_path
+            file_format = file_path.split(".")[1]
+        if isinstance(full_file_path, str):
+            if not os.path.exists(full_file_path):
+                raise AssertionError(f"File not found: {full_file_path}")
+            opener = open  # can add ability to handle zipped files here
+            mode = "rb" if file_format in {"pickle"} else "rt"
+            file_reader = opener(full_file_path, mode)
+        loaders = {
+            "pickle": lambda file_reader: pickle.load(file_reader),
+            "json": lambda file_reader: json.load(file_reader),
+        }
+        data = loaders[file_format](file_reader)
+        if verbosity > 2:
+            print(f"     File {full_file_path} loaded.")
+
+        return data
+
+    @staticmethod
+    def write_data_to_file(data, output_file_path, output_file_format, verbosity=0):
+        """ Takes a data object, writes and saves as a pickle or json. """
+
+        full_path = output_file_path + "." + output_file_format
+        if isinstance(full_path, str):
+            if output_file_format not in {"pickle", "json"}:
+                raise ValueError(f"Incompatible file format :{output_file_format}")
+            # Create folder if not already present
+            folder = os.path.dirname(full_path)
+            if folder and not os.path.exists(folder):
+                os.makedirs(folder)
+            mode = "wb" if output_file_format == "pickle" else "wt"
+            file_writer = open(full_path, mode)
+        else:
+            raise ValueError("full_path must be specified")
+
+        writers = {
+            "pickle": lambda file_writer: pickle.dump(data, file_writer, protocol=4),
+            "json": lambda file_writer: json.dump(data, file_writer, indent=2),
+        }
+        writers[output_file_format](file_writer)
+        file_writer.close()
+        if verbosity > 2:
+            print(f"     {full_path} saved.")


### PR DESCRIPTION
# Description

Creates the ScrapMEPSCodebook class and associated mgmt commands. This class is used to scrap variable parameter data for all data within SSP files. This data will assist in generating model classes for each SSP file.

Run with:
`python manage.py scrap_meps_codebook --sleep 0`

## Dependencies

None

## Migrations

None

## Checklist

- [ ] Lints
- [ ] Changelog Updated
